### PR TITLE
Explicitly calls python2 instead of python

### DIFF
--- a/enunciado/Makefile
+++ b/enunciado/Makefile
@@ -171,7 +171,7 @@ md_content.html: md_content.md
 enunciado: tarefa md_head.html md_content.html md_tail.html
 	@echo "Criando $(PAGE) da Tarefa $(ID)"; \
 	cat md_head.html md_content.html md_tail.html | \
-	python -c "$${INCLUDE_PY}" | \
+	python2 -c "$${INCLUDE_PY}" | \
 	sed "s#!ID!#$(ID)#g;s#!TITLE!#$(TITLE)#g;s#!MAX_SUBMISSIONS!#$(MAX_SUBMISSIONS)#g;" >$(PAGE)
 
 clean: tarefa


### PR DESCRIPTION
We are not in the 90's anymore and not everybody is stuck in time using
python2 as default.
